### PR TITLE
Fixed a random range bug when multiple items existed at one point

### DIFF
--- a/ItemSpawner/ItemsFileManager.cs
+++ b/ItemSpawner/ItemsFileManager.cs
@@ -148,7 +148,7 @@ namespace ItemSpawner
 					{
 						if (rand.Next(0, 10000) <= spawn.probability * 100)
 						{
-							Spawner.SpawnItem(room, spawn.items[rand.Next(0, spawn.items.Length - 1)], spawn.position, spawn.rotation);
+							Spawner.SpawnItem(room, spawn.items[rand.Next(0, spawn.items.Length)], spawn.position, spawn.rotation);
 						}
 					}
 				}


### PR DESCRIPTION
Fix incorrect random number range when pickup random item

### [How to reproduce]
Set your `items.txt` with bottom setting
`SCP_079:LOGICER,MEDKIT:100:6.603012,-3.255127,-6.357971:0.001277912,-0.9853523,-0.1705262`
Then you can see that only the `LOGICER` is always spawned.

If you add `COIN` to the configuration and test it again
`SCP_079:LOGICER,MEDKIT,COIN:100:6.603012,-3.255127,-6.357971:0.001277912,-0.9853523,-0.1705262`

Then you can see that only the `LOGICER, MEDKIT` is always spawned.